### PR TITLE
Use minutes instead of nanoseconds in interval env var

### DIFF
--- a/cmd/coronabot/main.go
+++ b/cmd/coronabot/main.go
@@ -46,7 +46,7 @@ func main() {
 	notify := application.NewNotifyService(slackClient, statusReporter, statusPerCountryToMessageService)
 
 	notifyInterval := notifyInterval()
-	notifyTimer := time.NewTicker(notifyInterval)
+	notifyTimer := time.NewTicker(notifyInterval * time.Minute)
 
 	for {
 		select {


### PR DESCRIPTION
NOTIFY_INTERVAL_MINUTES variable is currently read as nanoseconds and not as minutes.
