### PR TITLE
Limit Slack message to 50 most affected countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ## What is CoronaBot?
 CoronaBot is a simple Slack bot to update users about the Corona virus spread progression periodically.
 
+It shows the 50 most affected countries.
+
+
 ## Where does the data come from?
 Data comes from ArcGIS REST API.
 

--- a/internal/domain/service/status_list_to_message.go
+++ b/internal/domain/service/status_list_to_message.go
@@ -16,11 +16,16 @@ func NewStatusListToMessage() *StatusListToMessage {
 }
 
 func (s StatusListToMessage) Convert(statusList []model.Status) model.Message {
-	result := "```"
+	result := ":biohazard_sign: *|COVID-19|*\n"
+	result += "_50 Most affected countries:_\n"
+	result += "```"
 	result += fmt.Sprintf("|%20s|%10s|%7s|%10s|\n", "Country", "Confirmed", "Deaths", "Recovered")
 	result += fmt.Sprintf("|%20s|%10s|%7s|%10s|\n", "", "", "", "")
+	i := 0
 	for _, status := range statusList {
-		result += fmt.Sprintf("|%20s|%10d|%7d|%10d|\n", status.Country(), status.Confirmed(), status.Deaths(), status.Recovered())
+		if i++; i <= 50 {
+			result += fmt.Sprintf("|%20s|%10d|%7d|%10d|\n", status.Country(), status.Confirmed(), status.Deaths(), status.Recovered())
+		}
 	}
 	result += "```"
 	return model.NewMessage(result)


### PR DESCRIPTION
To limit the size of the Slack message, this PR limits the number of countries shown to 50.

Additionally, it adds a informational top message at the beginning.